### PR TITLE
Add lowering for all AST nodes

### DIFF
--- a/crates/mitki-analysis/src/hir/function.rs
+++ b/crates/mitki-analysis/src/hir/function.rs
@@ -209,22 +209,19 @@ impl<'db> FunctionBuilder<'db> {
             ast::Expr::Binary(binary) => {
                 let lhs = self.build_expr(binary.lhs(db));
                 let op_sym = binary.op(db).map(|op| op.into_symbol(self.db));
-                let op =
-                    op_sym.map(|sym| self.node_store.alloc_binding(sym)).unwrap_or(NodeId::ZERO);
+                let op = op_sym.map_or(NodeId::ZERO, |sym| self.node_store.alloc_binding(sym));
                 let rhs = self.build_expr(binary.rhs(db));
                 self.node_store.alloc_binary(lhs, op, rhs)
             }
             ast::Expr::Postfix(postfix) => {
                 let expr = self.build_expr(postfix.expr(db));
                 let op_sym = postfix.op(db).map(|op| op.into_symbol(self.db));
-                let op =
-                    op_sym.map(|sym| self.node_store.alloc_binding(sym)).unwrap_or(NodeId::ZERO);
+                let op = op_sym.map_or(NodeId::ZERO, |sym| self.node_store.alloc_binding(sym));
                 self.node_store.alloc_postfix(expr, op)
             }
             ast::Expr::Prefix(prefix) => {
                 let op_sym = prefix.op(db).map(|op| op.into_symbol(self.db));
-                let op =
-                    op_sym.map(|sym| self.node_store.alloc_binding(sym)).unwrap_or(NodeId::ZERO);
+                let op = op_sym.map_or(NodeId::ZERO, |sym| self.node_store.alloc_binding(sym));
                 let expr = self.build_expr(prefix.expr(db));
                 self.node_store.alloc_prefix(op, expr)
             }

--- a/crates/mitki-analysis/src/infer.rs
+++ b/crates/mitki-analysis/src/infer.rs
@@ -113,6 +113,43 @@ impl<'db> InferenceBuilder<'_, 'db> {
                     self.unit
                 }
             }
+            NodeKind::Binary => {
+                let binary = self.function.binary(node);
+                self.infer_node(binary.lhs, NoExpectation);
+                self.infer_node(binary.rhs, NoExpectation);
+                Ty::new(self.db, TyKind::Unknown)
+            }
+            NodeKind::Postfix => {
+                let postfix = self.function.postfix(node);
+                self.infer_node(postfix.expr, NoExpectation);
+                Ty::new(self.db, TyKind::Unknown)
+            }
+            NodeKind::Prefix => {
+                let prefix = self.function.prefix(node);
+                self.infer_node(prefix.expr, NoExpectation);
+                Ty::new(self.db, TyKind::Unknown)
+            }
+            NodeKind::If => {
+                let if_expr = self.function.if_expr(node);
+                self.infer_node(if_expr.cond, NoExpectation);
+                if if_expr.then_branch != NodeId::ZERO {
+                    self.infer_node(if_expr.then_branch, NoExpectation);
+                }
+                if if_expr.else_branch != NodeId::ZERO {
+                    self.infer_node(if_expr.else_branch, NoExpectation);
+                }
+                Ty::new(self.db, TyKind::Unknown)
+            }
+            NodeKind::Closure => {
+                let (params, body) = self.function.closure_parts(node);
+                for &param in params {
+                    self.inference.type_of_node.insert(param, self.unknown);
+                }
+                if body != NodeId::ZERO {
+                    self.infer_node(body, NoExpectation);
+                }
+                Ty::new(self.db, TyKind::Function)
+            }
             _ => Ty::new(self.db, TyKind::Unknown),
         };
         self.inference.type_of_node.insert(node, ty);


### PR DESCRIPTION
## Summary
- extend `NodeKind` to cover all AST nodes
- add allocation helpers for the new node kinds
- lower binary, prefix, postfix, if and closure expressions to HIR
- handle new nodes when creating expression scopes

## Testing
- `cargo test --quiet`
- `cargo fmt -- --check`


------
https://chatgpt.com/codex/tasks/task_e_68404ee08210832eb8984e7867ae04ab